### PR TITLE
Fix webpack config, rename library references in web examples

### DIFF
--- a/web/examples/compatible-c1.html
+++ b/web/examples/compatible-c1.html
@@ -8,7 +8,8 @@
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 
     <script type="text/javascript">
-        document.write('<script src="../dist/app.js?_v=' + (Math.random() + '') + '"></scr' + 'ipt>');
+        // ensure the library is always fully reloaded
+        document.write('<script src="../dist/libhalo.js?_v=' + (Math.random() + '') + '"></scr' + 'ipt>');
     </script>
 </head>
 <body>

--- a/web/examples/demo.html
+++ b/web/examples/demo.html
@@ -8,7 +8,8 @@
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 
     <script type="text/javascript">
-        document.write('<script src="../dist/app.js?_v=' + (Math.random() + '') + '"></scr' + 'ipt>');
+        // ensure the library is always fully reloaded
+        document.write('<script src="../dist/libhalo.js?_v=' + (Math.random() + '') + '"></scr' + 'ipt>');
     </script>
 </head>
 <body>

--- a/web/examples/simple.html
+++ b/web/examples/simple.html
@@ -8,7 +8,8 @@
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 
     <script type="text/javascript">
-        document.write('<script src="../dist/app.js?_v=' + (Math.random() + '') + '"></scr' + 'ipt>');
+        // ensure the library is always fully reloaded
+        document.write('<script src="../dist/libhalo.js?_v=' + (Math.random() + '') + '"></scr' + 'ipt>');
     </script>
 </head>
 <body>

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -2,6 +2,9 @@ module.exports = {
     entry: {
         app: './weblib.js',
     },
-    mode: 'development',
+    output: {
+        filename: 'libhalo.js'
+    },
+    mode: 'production',
     target: 'web',
 };


### PR DESCRIPTION
Set correct output name in webpack, rename examples to refer to the LibHaLo as `dist/libhalo.js`.