### PR TITLE
Lib: Add haloRecoverPublicKey() util function

### DIFF
--- a/docs/api-utils.md
+++ b/docs/api-utils.md
@@ -87,3 +87,48 @@ haloConvertSignature(
     "ether": "0xfb2ee8172a6cb2615276bcc7e7a56f1c299b93192b3af61406ffd8356c7303091b0afe49897224a009db67151f994633e32ef8f9f5e78a1b6ee506a2523e98ec1c"
 }
 ```
+
+## haloRecoverPublicKey
+
+Take the signed message digest and the resulting signature, compute two public key candidates.
+
+**Prototype:**
+All parameters should be hex-encoded strings.
+
+```javascript
+haloRecoverPublicKey(digest, derSignature);
+```
+
+**Example usage:**
+```javascript
+import {haloRecoverPublicKey} from '@arx-research/libhalo';
+
+const KEY_NO = 1;
+
+let signRes = await execHaloCmdWeb({
+    "name": "sign",
+    "message": "010203",
+    "keyNo": KEY_NO,
+    "legacySignCommand": true
+});
+
+// this will return two public keys
+// one of them will be actually the tag's public key
+console.log(haloRecoverPublicKey(signRes.input.digest, signRes.signature.der));
+```
+
+**Example function call:**
+```javascript
+haloRecoverPublicKey(
+    "bcf83051a4d206c6e43d7eaa4c75429737ac0d5ee08ee68430443bd815e6ac05",
+    "3046022100fb2ee8172a6cb2615276bcc7e7a56f1c299b93192b3af61406ffd8356c730309022100e4f501b6768ddb5ff62498eae066b9cad77fe3ecb961162050ed57ea7df7a855"
+);
+```
+
+**Example return value:**
+```javascript
+[
+  '04c057b11fd0ecaad8decc4df64de9b95d1b41fad96017c82d809eabc5240fa7d9cac3d65e1412d5f103598f1541eaeb6e27dc401b6a873576322cfd73074aebd8',
+  '04e2b8ec92be2ed99962470555b31f094a1862d7fa3fb8a5de1f4d7f475bd93ffb27d7295e94ac11e8fa67b70582df375fc660c5e36078e83f7a1e9f7e6ae08142' 
+]
+```

--- a/halo/utils.js
+++ b/halo/utils.js
@@ -129,6 +129,19 @@ function convertSignature(digest, signature, publicKey) {
     };
 }
 
+function recoverPublicKey(digest, signature) {
+    let out = [];
+
+    signature = Buffer.from(signature, "hex");
+    let fixedSig = parseSig(signature);
+
+    for (let i = 0; i < 2; i++) {
+        out.push(ec.recoverPubKey(new BN(digest, 16), fixedSig, i).encode('hex'));
+    }
+
+    return out;
+}
+
 function mode(arr) {
     return arr.sort((a, b) =>
         arr.filter(v => v === a).length
@@ -142,5 +155,6 @@ module.exports = {
     parseSig,
     convertSignature,
     parsePublicKeys,
+    recoverPublicKey,
     mode
 };

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const {
     NFCAbortedError,
     NFCOperationError
 } = require("./halo/exceptions");
-const {parsePublicKeys, convertSignature} = require("./halo/utils");
+const {parsePublicKeys, convertSignature, recoverPublicKey} = require("./halo/utils");
 
 /**
  * The LibHaLo stable API. Please don't depend on the functions imported from anywhere else
@@ -36,6 +36,7 @@ module.exports = {
     // exported utils
     haloParsePublicKeys: parsePublicKeys,
     haloConvertSignature: convertSignature,
+    haloRecoverPublicKey: recoverPublicKey,
 
     // exceptions
     HaloTagError,

--- a/web/weblib.js
+++ b/web/weblib.js
@@ -16,7 +16,7 @@ const {
     NFCOperationError
 } = require("../halo/exceptions");
 const {
-    arr2hex, hex2arr, parsePublicKeys, convertSignature
+    arr2hex, hex2arr, parsePublicKeys, convertSignature, recoverPublicKey
 } = require("../halo/utils");
 const {__runTestSuite} = require("../halo/tests");
 
@@ -26,6 +26,7 @@ module.exports = {
     hex2arr,
     haloParsePublicKeys: parsePublicKeys,
     haloConvertSignature: convertSignature,
+    haloRecoverPublicKey: recoverPublicKey,
 
     // for web usage
     execHaloCmdWeb,


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Add `haloRecoverPublicKey()` utility function to make it possible to recover public keys out of messages and signatures.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [x] (PR Author) The change was manually tested with the web library in either standalone mode or with React.js
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
