### PR TITLE
Bridge: Use selfsigned TLS certificate on Mac OS

### DIFF
--- a/.github/workflows/prod_build_cli.yml
+++ b/.github/workflows/prod_build_cli.yml
@@ -111,6 +111,7 @@ jobs:
           node_modules/.bin/pkg --compress GZip -t node16-macos-x64 -c package.json -o dist/halocli entry_cli.js
           node_modules/.bin/pkg --compress GZip -t node16-macos-x64 -c package.json -o dist/halo-bridge entry_bridge.js
           mv "macos_bridge_app" "dist/HaLo CLI Bridge Server.app"
+          mv "macos_pkgbuild_scripts" "dist/macos_pkgbuild_scripts"
           mv "Entitlements.plist" "dist/Entitlements.plist"
       - name: Compress dist files
         shell: bash
@@ -223,7 +224,7 @@ jobs:
           chmod +x ./root/usr/local/bin/halocli
           chmod +x ./root/usr/local/bin/halo-bridge
           chmod +x "./root/Applications/HaLo CLI Bridge Server.app/Contents/MacOS/halocli_bridge_launcher"
-          pkgbuild --root ./root --identifier "org.arx.halo.halocli" --version "1.0.$(date +%s)" --install-location "/" --sign "${{ secrets.MACOS_SIGN_IDENTITY_INSTALLER }}" ./halocli-macos-x64.pkg
+          pkgbuild --root ./root --identifier "org.arx.halo.halocli" --version "1.0.$(date +%s)" --scripts "macos_pkgbuild_scripts/" --install-location "/" --sign "${{ secrets.MACOS_SIGN_IDENTITY_INSTALLER }}" ./halocli-macos-x64.pkg
       - name: Notarize application for Mac OS
         if: matrix.os == 'macos-latest'
         run: |

--- a/cli/args_bridge.js
+++ b/cli/args_bridge.js
@@ -16,10 +16,16 @@ parser.add_argument("-l", "--listen-host", {
     dest: "listenHost"
 });
 parser.add_argument("-p", "--listen-port", {
-    help: "Port where the server should bind",
+    help: "Port where the server should bind (HTTP/WS)",
     type: "int",
     default: 32868,
     dest: "listenPort"
+});
+parser.add_argument("-P", "--listen-port-tls", {
+    help: "Port where the server should bind (HTTPS/WSS)",
+    type: "int",
+    default: 32869,
+    dest: "listenPortTLS"
 });
 parser.add_argument("-a", "--allow-origins", {
     help: "List of origins that are allowed to connect (semicolon-separated)",

--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -21,7 +21,7 @@
         document.getElementById('log').innerText += '\n' + data;
     }
 
-    let wsp = createWs('ws://localhost:32868');
+    let wsp = createWs('wss://localhost:32869');
 
     async function execHaloCommand(command) {
         log('Executing command: ' + JSON.stringify(command));

--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -21,7 +21,15 @@
         document.getElementById('log').innerText += '\n' + data;
     }
 
-    let wsp = createWs('wss://localhost:32869');
+    let wsAddress;
+
+    if (window.location.protocol === 'https:') {
+        wsAddress = 'wss://halo-bridge.local:32869';
+    } else {
+        wsAddress = 'ws://localhost:32868';
+    }
+
+    let wsp = createWs(wsAddress);
 
     async function execHaloCommand(command) {
         log('Executing command: ' + JSON.stringify(command));

--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -22,11 +22,22 @@
     }
 
     let wsAddress;
+    let wsPort;
+
+    if (!window.location.host.includes(':')) {
+        if (window.location.protocol === 'https:') {
+            wsPort = 443;
+        } else {
+            wsPort = 80;
+        }
+    } else {
+        wsPort = parseInt(window.location.host.split(':')[1]);
+    }
 
     if (window.location.protocol === 'https:') {
-        wsAddress = 'wss://halo-bridge.local:32869';
+        wsAddress = 'wss://halo-bridge.local:' + wsPort;
     } else {
-        wsAddress = 'ws://localhost:32868';
+        wsAddress = 'ws://127.0.0.1:' + wsPort;
     }
 
     let wsp = createWs(wsAddress);

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -149,11 +149,16 @@ function runHalo(entryMode, args) {
 
     if (entryMode === "server") {
         console.log('Launching Web Socket Server...');
-        wsCreateServer(args, () => Object.keys(nfc.readers).map(r => nfc.readers[r].name));
+        let serverInfo = wsCreateServer(
+            args, () => Object.keys(nfc.readers).map(r => nfc.readers[r].name));
         console.log('Web Socket Server is listening...');
 
         if (!args.nonInteractive) {
-            open('http://127.0.0.1:' + args.listenPort);
+            if (serverInfo.hasTLS) {
+                open('https://halo-bridge.local:' + args.listenPortTLS);
+            } else {
+                open('http://127.0.0.1:' + args.listenPort);
+            }
         }
     } else {
         stopPCSCTimeout = setTimeout(stopPCSC, 4000, "timeout", args.output);

--- a/cli/macos_pkgbuild_scripts/postinstall
+++ b/cli/macos_pkgbuild_scripts/postinstall
@@ -21,6 +21,9 @@ openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048
 openssl req -new -sha256 -key /usr/local/etc/halo-bridge/private_key.pem -out /usr/local/etc/halo-bridge/server.csr -subj '/CN=halo-bridge.local/'
 openssl req -x509 -sha256 -days 3650 -key /usr/local/etc/halo-bridge/private_key.pem -in /usr/local/etc/halo-bridge/server.csr -out /usr/local/etc/halo-bridge/server.pem
 
+# notify user that we are going to modify the trust list
+osascript -e 'display alert "HaLo CLI Installer" message "We will generate a self-signed certificate for halo-bridge'\''s local domain and mark it as trusted in the system.\n\nThis step is required in order to support Safari web browser."'
+
 # add certificate to the trust list
 security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/etc/halo-bridge/server.pem
 

--- a/cli/macos_pkgbuild_scripts/postinstall
+++ b/cli/macos_pkgbuild_scripts/postinstall
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# check if user requested us not to override the certificate
+if [ -f /usr/local/etc/halo-bridge/DONT_OVERRIDE ]
+then
+    exit 0
+fi
+
+# create a directory for our certificate
+mkdir /usr/local/etc/halo-bridge
+
+# generate new local certificate
+openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048
+openssl req -new -sha256 -key /usr/local/etc/halo-bridge/private_key.pem -out /usr/local/etc/halo-bridge/server.csr -subj '/CN=halo-bridge.local/'
+openssl req -x509 -sha256 -days 3650 -key /usr/local/etc/halo-bridge/private_key.pem -in /usr/local/etc/halo-bridge/server.csr -out /usr/local/etc/halo-bridge/server.pem
+
+# add certificate to the trust list
+security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/etc/halo-bridge/server.pem
+
+exit 0

--- a/cli/macos_pkgbuild_scripts/postinstall
+++ b/cli/macos_pkgbuild_scripts/postinstall
@@ -9,7 +9,12 @@ then
 fi
 
 # create a directory for our certificate
-mkdir /usr/local/etc/halo-bridge
+mkdir -p /usr/local/etc/halo-bridge
+
+# remove stale files
+rm -f /usr/local/etc/halo-bridge/private_key.pem
+rm -f /usr/local/etc/halo-bridge/server.csr
+rm -f /usr/local/etc/halo-bridge/server.csr
 
 # generate new local certificate
 openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048
@@ -18,5 +23,11 @@ openssl req -x509 -sha256 -days 3650 -key /usr/local/etc/halo-bridge/private_key
 
 # add certificate to the trust list
 security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/etc/halo-bridge/server.pem
+
+# add halo-bridge.local domain to /etc/hosts if it doesn't exist yet
+if ! grep -q "halo-bridge.local" /etc/hosts
+then
+  echo "127.0.0.1  halo-bridge.local" >> /etc/hosts
+fi
 
 exit 0

--- a/cli/macos_pkgbuild_scripts/postinstall
+++ b/cli/macos_pkgbuild_scripts/postinstall
@@ -19,7 +19,7 @@ rm -f /usr/local/etc/halo-bridge/server.csr
 # generate new local certificate
 openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048
 openssl req -new -sha256 -key /usr/local/etc/halo-bridge/private_key.pem -out /usr/local/etc/halo-bridge/server.csr -subj '/CN=halo-bridge.local/'
-openssl req -x509 -sha256 -days 3650 -key /usr/local/etc/halo-bridge/private_key.pem -in /usr/local/etc/halo-bridge/server.csr -out /usr/local/etc/halo-bridge/server.pem
+openssl req -x509 -sha256 -days 3650 -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName='DNS:halo-bridge.local'")) -key /usr/local/etc/halo-bridge/private_key.pem -in /usr/local/etc/halo-bridge/server.csr -out /usr/local/etc/halo-bridge/server.pem
 
 # notify user that we are going to modify the trust list
 osascript -e 'display alert "HaLo CLI Installer" message "We will generate a self-signed certificate for halo-bridge'\''s local domain and mark it as trusted in the system.\n\nThis step is required in order to support Safari web browser."'

--- a/cli/ws_server.js
+++ b/cli/ws_server.js
@@ -5,6 +5,8 @@ const crypto = require('crypto').webcrypto;
 const {execHaloCmdPCSC} = require('../index.js');
 const {dirname, randomBuffer} = require("./util");
 const jwt = require('jsonwebtoken');
+const https = require("https");
+const fs = require("fs");
 
 let wss = null;
 
@@ -116,8 +118,16 @@ function wsEventReaderDisconnected(reader) {
 }
 
 function wsCreateServer(args, getReaderNames) {
+    const privateKey = fs.readFileSync('private_key.pem');
+    const certificate = fs.readFileSync('server.pem');
+
     const app = express();
     const server = app.listen(args.listenPort, args.listenHost);
+
+    https.createServer({
+        key: privateKey,
+        cert: certificate
+    }, app).listen(args.listenPort + 1);
 
     wss = new WebSocketServer({noServer: true});
 

--- a/cli/ws_server.js
+++ b/cli/ws_server.js
@@ -317,6 +317,8 @@ function wsCreateServer(args, getReaderNames) {
             });
         }
     });
+
+    return {hasTLS: !!serverTLS};
 }
 
 module.exports = {


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Right now halo-bridge is not useable on Mac OS Safari due to strict mixed content policy. Its not possible for HTTPS website to connect with a localhost websocket, even though other browsers and platforms allow that.

The Mac OS installer will just generate a self-signed TLS certificate on users local machine and mark it as trusted.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [x] (PR Author) The change was manually tested with the CLI
* [x] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library in either standalone mode or with React.js
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
