### PR TITLE
Bridge installer: Ask the user whether he wants to generate a certificate

### DIFF
--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -102,6 +102,15 @@
     });
 
     wsp.onClose.addListener(event => {
+        {% if displayTLSWarn %}
+            if (event.code === 1006) {
+                log('IMPORTANT: You might be missing a local certificate, which is required for halo-bridge on Safari. ' +
+                    'If the halo-bridge doesn\'t work at all, please try to reinstall the entire toolset using the ' +
+                    'release PKG file. When the installer will ask you about certificate generation, ' +
+                    'please choose "Generate certificate" option.');
+            }
+        {% endif %}
+
         if (event.code === 4001) {
             log('Connection closed, new client has connected.');
         } else {

--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -18,6 +18,8 @@
 <script>
     const forceUseTLS = {% if forceUseTLS %}true{% else %}false{% endif %};
     const displayTLSWarn = {% if displayTLSWarn %}true{% else %}false{% endif %};
+    const wsPort = {{ wsPort }};
+    const wssPort = {{ wssPort }};
 
     function log(data) {
         console.log(data);
@@ -25,20 +27,9 @@
     }
 
     let wsAddress;
-    let wsPort;
-
-    if (!window.location.host.includes(':')) {
-        if (window.location.protocol === 'https:') {
-            wsPort = 443;
-        } else {
-            wsPort = 80;
-        }
-    } else {
-        wsPort = parseInt(window.location.host.split(':')[1]);
-    }
 
     if (window.location.protocol === 'https:' || forceUseTLS) {
-        wsAddress = 'wss://halo-bridge.local:' + wsPort;
+        wsAddress = 'wss://halo-bridge.local:' + wssPort;
     } else {
         wsAddress = 'ws://127.0.0.1:' + wsPort;
     }

--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -16,6 +16,9 @@
 </div>
 <script src="/assets/static/ws_client.js"></script>
 <script>
+    const forceUseTLS = {% if forceUseTLS %}true{% else %}false{% endif %};
+    const displayTLSWarn = {% if displayTLSWarn %}true{% else %}false{% endif %};
+
     function log(data) {
         console.log(data);
         document.getElementById('log').innerText += '\n' + data;
@@ -34,7 +37,7 @@
         wsPort = parseInt(window.location.host.split(':')[1]);
     }
 
-    if (window.location.protocol === 'https:') {
+    if (window.location.protocol === 'https:' || forceUseTLS) {
         wsAddress = 'wss://halo-bridge.local:' + wsPort;
     } else {
         wsAddress = 'ws://127.0.0.1:' + wsPort;
@@ -102,14 +105,12 @@
     });
 
     wsp.onClose.addListener(event => {
-        {% if displayTLSWarn %}
-            if (event.code === 1006) {
-                log('IMPORTANT: You might be missing a local certificate, which is required for halo-bridge on Safari. ' +
-                    'If the halo-bridge doesn\'t work at all, please try to reinstall the entire toolset using the ' +
-                    'release PKG file. When the installer will ask you about certificate generation, ' +
-                    'please choose "Generate certificate" option.');
-            }
-        {% endif %}
+        if (event.code === 1006 && displayTLSWarn) {
+            log('IMPORTANT: You might be missing a local certificate, which is required for halo-bridge on Safari. ' +
+                'If the halo-bridge doesn\'t work at all, please try to reinstall the entire toolset using the ' +
+                'release PKG file. When the installer will ask you about certificate generation, ' +
+                'please choose "Generate certificate" option.');
+        }
 
         if (event.code === 4001) {
             log('Connection closed, new client has connected.');

--- a/cli/macos_pkgbuild_scripts/postinstall
+++ b/cli/macos_pkgbuild_scripts/postinstall
@@ -17,7 +17,7 @@ rm -f /usr/local/etc/halo-bridge/server.csr
 rm -f /usr/local/etc/halo-bridge/server.csr
 
 # ask user whether he wants to generate a certificate for halo-bridge.local
-if osascript -e 'display dialog "In order for halo-bridge to work correctly, we will need to generate a self-signed certificate for the '\''halo-bridge.local'\'' domain and mark it as trusted in the system.\n\nYou can skip that step if you don'\''t need to use halo-bridge tool." buttons {"Skip", "Generate certificate"} default button "Generate certificate" cancel button "Skip" with icon caution with title "HaLo CLI Installer"'
+if osascript -e 'display dialog "In order for halo-bridge to work correctly, we will need to generate a self-signed certificate for the '\''halo-bridge.local'\'' domain and mark it as trusted in the system.\n\nYou can skip that step if you don'\''t need to use halo-bridge tool." buttons {"Skip", "Generate certificate"} default button "Generate certificate" cancel button "Skip" with icon caution with title "HaLo Tools Installer"'
 then
   # generate new local certificate
   openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048

--- a/cli/macos_pkgbuild_scripts/postinstall
+++ b/cli/macos_pkgbuild_scripts/postinstall
@@ -16,16 +16,17 @@ rm -f /usr/local/etc/halo-bridge/private_key.pem
 rm -f /usr/local/etc/halo-bridge/server.csr
 rm -f /usr/local/etc/halo-bridge/server.csr
 
-# generate new local certificate
-openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048
-openssl req -new -sha256 -key /usr/local/etc/halo-bridge/private_key.pem -out /usr/local/etc/halo-bridge/server.csr -subj '/CN=halo-bridge.local/'
-openssl req -x509 -sha256 -days 3650 -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName='DNS:halo-bridge.local'")) -key /usr/local/etc/halo-bridge/private_key.pem -in /usr/local/etc/halo-bridge/server.csr -out /usr/local/etc/halo-bridge/server.pem
+# ask user whether he wants to generate a certificate for halo-bridge.local
+if osascript -e 'display dialog "In order for halo-bridge to work correctly, we will need to generate a self-signed certificate for the '\''halo-bridge.local'\'' domain and mark it as trusted in the system.\n\nYou can skip that step if you don'\''t need to use halo-bridge tool." buttons {"Skip", "Generate certificate"} default button "Generate certificate" cancel button "Skip" with icon caution with title "HaLo CLI Installer"'
+then
+  # generate new local certificate
+  openssl genrsa -out /usr/local/etc/halo-bridge/private_key.pem 2048
+  openssl req -new -sha256 -key /usr/local/etc/halo-bridge/private_key.pem -out /usr/local/etc/halo-bridge/server.csr -subj '/CN=halo-bridge.local/'
+  openssl req -x509 -sha256 -days 3650 -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName='DNS:halo-bridge.local'")) -key /usr/local/etc/halo-bridge/private_key.pem -in /usr/local/etc/halo-bridge/server.csr -out /usr/local/etc/halo-bridge/server.pem
 
-# notify user that we are going to modify the trust list
-osascript -e 'display alert "HaLo CLI Installer" message "We will generate a self-signed certificate for halo-bridge'\''s local domain and mark it as trusted in the system.\n\nThis step is required in order to support Safari web browser."'
-
-# add certificate to the trust list
-security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/etc/halo-bridge/server.pem
+  # add certificate to the trust list
+  security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /usr/local/etc/halo-bridge/server.pem
+fi
 
 # add halo-bridge.local domain to /etc/hosts if it doesn't exist yet
 if ! grep -q "halo-bridge.local" /etc/hosts

--- a/cli/ws_server.js
+++ b/cli/ws_server.js
@@ -173,7 +173,9 @@ function wsCreateServer(args, getReaderNames) {
     app.get('/', (req, res) => {
         res.render('ws_client.html', {
             forceUseTLS: forceUseTLS,
-            displayTLSWarn: displayTLSWarn
+            displayTLSWarn: displayTLSWarn,
+            wsPort: args.listenPort,
+            wssPort: args.listenPortTLS
         });
     });
 

--- a/cli/ws_server.js
+++ b/cli/ws_server.js
@@ -148,6 +148,7 @@ function wsCreateServer(args, getReaderNames) {
     const app = express();
     const server = app.listen(args.listenPort, args.listenHost);
 
+    let forceUseTLS = (process.platform === "darwin");
     let displayTLSWarn = (process.platform === "darwin");
 
     if (tlsData) {
@@ -170,7 +171,10 @@ function wsCreateServer(args, getReaderNames) {
     });
 
     app.get('/', (req, res) => {
-        res.render('ws_client.html', {displayTLSWarn: displayTLSWarn});
+        res.render('ws_client.html', {
+            forceUseTLS: forceUseTLS,
+            displayTLSWarn: displayTLSWarn
+        });
     });
 
     app.get('/consent', async (req, res) => {

--- a/cli/ws_server.js
+++ b/cli/ws_server.js
@@ -148,11 +148,15 @@ function wsCreateServer(args, getReaderNames) {
     const app = express();
     const server = app.listen(args.listenPort, args.listenHost);
 
+    let displayTLSWarn = (process.platform === "darwin");
+
     if (tlsData) {
         serverTLS = https.createServer({
             key: tlsData.privateKey,
             cert: tlsData.certificate
         }, app).listen(args.listenPortTLS, args.listenHost);
+
+        displayTLSWarn = false;
     }
 
     wss = new WebSocketServer({noServer: true});
@@ -166,7 +170,7 @@ function wsCreateServer(args, getReaderNames) {
     });
 
     app.get('/', (req, res) => {
-        res.render('ws_client.html');
+        res.render('ws_client.html', {displayTLSWarn: displayTLSWarn});
     });
 
     app.get('/consent', async (req, res) => {


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Mac OS installer will give the user an option whether he wants to generate a local certificate or not.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library in either standalone mode or with React.js
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
