### PR TITLE
Bridge: don't report WebSocket events on cards that are not HaLo compatible

### DIFF
--- a/cli/assets/views/ws_client.html
+++ b/cli/assets/views/ws_client.html
@@ -85,6 +85,9 @@
                     case 'handle_removed':
                         log('Removed tag: ' + ev.data.reader_name + ' (handle: ' + ev.data.handle + ')');
                         break;
+                    case 'handle_not_compatible':
+                        log('Detected incompatible tag: ' + ev.data.reader_name + ' (message: ' + ev.data.message + ')');
+                        break;
                 }
             }
 

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -43,7 +43,13 @@ function runHalo(entryMode, args) {
 
         reader.on('card', card => {
             if (entryMode === "server") {
-                wsEventCardConnected(reader);
+                (async () => {
+                    if (await checkCard(reader)) {
+                        wsEventCardConnected(reader);
+                    } else {
+                        console.log("Tag ignored:", reader.reader.name, "Not a HaLo tag.");
+                    }
+                })();
                 return;
             }
 

--- a/cli/ws_server.js
+++ b/cli/ws_server.js
@@ -86,6 +86,17 @@ function wsEventCardConnected(reader) {
     });
 }
 
+function wsEventCardIncompatible(reader) {
+    sendToCurrentWs(null, {
+        "event": "handle_not_compatible",
+        "uid": null,
+        "data": {
+            "reader_name": reader.reader.name,
+            "message": "Denying access to the resource since it's not a HaLo tag."
+        }
+    });
+}
+
 function wsEventCardDisconnected(reader) {
     if (currentState !== null && currentState.reader === reader) {
         sendToCurrentWs(null, {
@@ -356,6 +367,7 @@ function wsCreateServer(args, getReaderNames) {
 module.exports = {
     wsCreateServer,
     wsEventCardConnected,
+    wsEventCardIncompatible,
     wsEventCardDisconnected,
     wsEventReaderConnected,
     wsEventReaderDisconnected

--- a/docs/halo-bridge.md
+++ b/docs/halo-bridge.md
@@ -87,6 +87,7 @@ Possible incoming events are the following:
 * `reader_removed` - the existing NFC reader was disconnected, the reader's name will be provided as `data.reader_name`;
 * `handle_added` - a reader has detected new HaLo tag (`data.reader_name` - reader's name, `data.handle` - random value, a handle to the connected tag);
 * `handle_removed` - a reader has detected that HaLo tag was un-tapped (`data.reader_name` - reader's name, `data.handle` - random value, a handle to the connected tag);
+* `handle_not_compatible` - a reader has detected a tag, but it's not compatible with HaLo and thus any interaction will be impossible (`data.reader_name` - reader's name, `data.message` - description why the tag is not compatible);
 * `exec_success` - HaLo command execution has succeeded, (`uid` - identifier of the command request; `data.*` - command execution result);
 * `exec_exception` - HaLo command failed to execute (`data.exception.message` - exception message, `data.exception.stack` - full call stack of the exception);
 


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Right now HaLo Bridge could detect YubiKeys or other PC/SC compatible cards. Let's make it so HaLo Bridge will first try to select HaLo Core Applet. The card won't be reported at all if it's not compatible.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [x] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library in either standalone mode or with React.js
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
