### PR TITLE
Bridge: reorder WS/WSS health checks

### DIFF
--- a/web/web_utils.js
+++ b/web/web_utils.js
@@ -43,8 +43,8 @@ function runHealthCheck(url) {
 
 function createChecks(wsPort, wssPort) {
     return [
-        runHealthCheck('wss://halo-bridge.local:' + wssPort + '/ws'),
-        runHealthCheck('ws://127.0.0.1:' + wsPort + '/ws')
+        runHealthCheck('ws://127.0.0.1:' + wsPort + '/ws'),
+        runHealthCheck('wss://halo-bridge.local:' + wssPort + '/ws')
     ];
 }
 

--- a/web/web_utils.js
+++ b/web/web_utils.js
@@ -43,6 +43,12 @@ function runHealthCheck(url) {
 
 function createChecks(wsPort, wssPort) {
     return [
+        /**
+         Please note that this order of operations is important.
+         The ws:// request would always fail fast if the browser's policy doesn't allow such connection.
+         Certain browsers would process WebSocket connect orders sequentially (not in parallel!),
+         and the TLS error might block the connection for many seconds until it actually fails.
+         **/
         runHealthCheck('ws://127.0.0.1:' + wsPort + '/ws'),
         runHealthCheck('wss://halo-bridge.local:' + wssPort + '/ws')
     ];


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Currently, Firefox under Mac OS would first try to connect to `wss://` endpoint, which would always fail anyway. We don't install our self-signed `halo-bridge.local` certificate into Firefox's trust store, so it has no chance to work.

This is not a problem for any other browser, but Firefox would block the second request towards `ws://` until the first request towards `wss://` fails, which could take many seconds. This leads to a timeout on both requests and causes haloFindBridge() being unable to find the correct bridge address.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [x] (PR Author) The change was manually tested with the web library in either standalone mode or with React.js
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
