### PR TITLE
Web: Fix bug that was causing WebNFC throwing "retry" error when libhalo is running under frontend frameworks

### DIFF
--- a/drivers/webnfc.js
+++ b/drivers/webnfc.js
@@ -11,7 +11,7 @@ const {
     NFCPermissionRequestDenied,
     NFCAbortedError
 } = require("../halo/exceptions");
-const {arr2hex} = require("../halo/utils");
+const {arr2hex, hex2arr} = require("../halo/utils");
 
 let ndef = null;
 let ctrl = null;


### PR DESCRIPTION


## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [X] (PR Author) The change was manually tested with the web library in either standalone mode or with React.js
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
