### PR TITLE
Web: Fix WebNFC bug with version C3 when parsing public keys

### DIFF
--- a/halo/commands.js
+++ b/halo/commands.js
@@ -38,7 +38,7 @@ function extractPublicKeyWebNFC(keyNo, resp) {
         publicKey = Buffer.from(resp.extra[pkKey], "hex");
     } else if (resp.extra.hasOwnProperty("static")) {
         let pkeys = parsePublicKeys(Buffer.from(resp.extra["static"], "hex"));
-        publicKey = pkeys[pkKey];
+        publicKey = pkeys[keyNo];
     }
 
     return publicKey;


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [x] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
