### PR TITLE
Feature/check webnfc perm

### DIFF
--- a/api/web.js
+++ b/api/web.js
@@ -4,12 +4,11 @@
  * License: MIT
  */
 
-const {
-    execHaloCmdWeb, detectMethod
-} = require("../drivers/common");
 const {HaloGateway} = require("../halo/gateway/requestor");
 const {haloFindBridge} = require("../web/web_utils");
 const {haloGateExecutorCreateWs, haloGateExecutorUserConfirm} = require("../halo/gateway/executor");
+const {execHaloCmdWeb, detectMethod} = require("../drivers/web");
+const {checkWebNFCPermission} = require("../drivers/webnfc");
 
 /**
  * The LibHaLo stable API. Please don't depend on the functions imported from anywhere else
@@ -20,6 +19,7 @@ module.exports = {
     execHaloCmdWeb,
     haloFindBridge,
     haloGetDefaultMethod: detectMethod,
+    haloCheckWebNFCPermission: checkWebNFCPermission,
 
     // for web usage with gateway
     HaloGateway,

--- a/drivers/web.js
+++ b/drivers/web.js
@@ -1,0 +1,88 @@
+const {NFCAbortedError, NFCMethodNotSupported} = require("../halo/exceptions");
+const {execCredential} = require("./credential");
+const {execWebNFC} = require("./webnfc");
+const {execHaloCmd} = require("./common");
+
+let isCallRunning = null;
+
+function makeDefault(curValue, defaultValue) {
+    if (typeof curValue === "undefined") {
+        return defaultValue;
+    }
+
+    if (curValue === null) {
+        return defaultValue;
+    }
+
+    return curValue;
+}
+
+/**
+ * Detect the best command execution method for the current device.
+ * @returns {string} Either "credential" or "webnfc".
+ */
+function detectMethod() {
+    try {
+        new NDEFReader();
+    } catch (e) {
+        // WebNFC not supported
+        return "credential";
+    }
+
+    return "webnfc";
+}
+
+/**
+ * Execute the NFC command from the web browser.
+ * @param command Command specification object.
+ * @param options Additional options for the command executor.
+ * @returns {Promise<*>} Command execution result.
+ */
+async function execHaloCmdWeb(command, options) {
+    if (options && !options.noDebounce && isCallRunning) {
+        throw new NFCAbortedError("The operation was debounced.");
+    }
+
+    isCallRunning = true;
+
+    options = options ? Object.assign({}, options) : {};
+    options.method = makeDefault(options.method, detectMethod());
+    options.noDebounce = makeDefault(options.noDebounce, false);
+    options.compatibleCallMode = makeDefault(options.compatibleCallMode, true);
+
+    command = command ? Object.assign({}, command) : {};
+
+    try {
+        let cmdOpts = {};
+
+        if (options.method === "credential") {
+            cmdOpts = {
+                method: "credential",
+                exec: async (command) => await execCredential(command, {
+                    debugCallback: options.debugCallback,
+                    statusCallback: options.statusCallback,
+                    compatibleCallMode: options.compatibleCallMode
+                })
+            };
+        } else if (options.method === "webnfc") {
+            cmdOpts = {
+                method: "webnfc",
+                exec: async (command) => await execWebNFC(command, {
+                    debugCallback: options.debugCallback,
+                    statusCallback: options.statusCallback
+                })
+            };
+        } else {
+            throw new NFCMethodNotSupported("Unsupported options.method parameter specified.");
+        }
+
+        return await execHaloCmd(command, cmdOpts);
+    } finally {
+        isCallRunning = false;
+    }
+}
+
+module.exports = {
+    execHaloCmdWeb,
+    detectMethod
+};

--- a/drivers/webnfc.js
+++ b/drivers/webnfc.js
@@ -16,6 +16,30 @@ const {arr2hex, hex2arr} = require("../halo/utils");
 let ndef = null;
 let ctrl = null;
 
+/**
+ * Check if user has granted us permission to use WebNFC interface.
+ * @returns {Promise<boolean>}
+ */
+async function checkWebNFCPermission() {
+    if (!window.isSecureContext) {
+        throw new NFCMethodNotSupported("This method can be invoked only in the secure context (HTTPS).");
+    }
+
+    try {
+        const controller = new AbortController();
+        const ndef = new NDEFReader();
+        await ndef.scan({ signal: controller.signal });
+        controller.abort();
+        return true;
+    } catch (e) {
+        if (e.name === "NotAllowedError") {
+            return false;
+        }
+
+        throw e;
+    }
+}
+
 async function execWebNFC(request, options) {
     if (!window.isSecureContext) {
         throw new NFCMethodNotSupported("This method can be invoked only in the secure context (HTTPS).");
@@ -136,5 +160,6 @@ async function execWebNFC(request, options) {
 }
 
 module.exports = {
+    checkWebNFCPermission,
     execWebNFC
 };

--- a/drivers/webnfc.js
+++ b/drivers/webnfc.js
@@ -15,6 +15,18 @@ const {arr2hex, hex2arr} = require("../halo/utils");
 
 let ndef = null;
 let ctrl = null;
+let blurEventInstalled = false;
+
+function detectWindowMinimized() {
+    if (ctrl) {
+        /*
+        Once the web page gets minimized, the call to NFCReader.scan() or NFCReader.write() might still appear
+        to be running, although the NFC scanning feature will be glitched. We need to detect that the page
+        was minimized and abort the call in order to work-around the bug.
+         */
+        ctrl.abort();
+    }
+}
 
 /**
  * Check if user has granted us permission to use WebNFC interface.
@@ -69,6 +81,11 @@ async function execWebNFC(request, options) {
         }
     }
 
+    if (!blurEventInstalled) {
+        window.addEventListener('visibilitychange', detectWindowMinimized);
+        blurEventInstalled = true;
+    }
+
     let writeStatus = "nfc-write";
 
     while (true) {
@@ -87,13 +104,17 @@ async function execWebNFC(request, options) {
                 options.statusCallback("retry", "webnfc", "nfc-write-error");
             }
 
-            await ndef.write({records: [{recordType: "unknown", data: request}]});
+            await ndef.write({
+                records: [{recordType: "unknown", data: request}]
+            }, {
+                signal: ctrl.signal
+            });
             break;
         } catch (e) {
             if (e.name === "NotAllowedError") {
                 throw new NFCPermissionRequestDenied("NFC permission request denied by the user.");
             } else if (e.name === "AbortError") {
-                throw new NFCAbortedError("Operation restarted by the user.");
+                throw new NFCAbortedError("Operation restarted by the user or webpage minimized (during write).");
             } else {
                 writeStatus = "nfc-write-error";
             }
@@ -105,6 +126,14 @@ async function execWebNFC(request, options) {
     options.debugCallback("nfc-read");
 
     return new Promise((resolve, reject) => {
+        ctrl.signal.addEventListener('abort', () => {
+            reject(new NFCAbortedError("Operation restarted by the user or webpage minimized (during read)."));
+        });
+
+        if (ctrl.signal.aborted) {
+            reject(new NFCAbortedError("Operation restarted by the user or webpage minimized (during read)."));
+        }
+
         ndef.onreadingerror = (event) => {
             options.debugCallback("nfc-read-error");
             options.statusCallback("retry", "webnfc", "nfc-read-error");


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
It seems like there is a bug in WebNFC's NFCReader. When the web page is minimized, the call still appears to be pending, although it will become glitched. When the page is minimized on the phone and then maximized, the scans will not arrive into WebNFC API but would be directly dispatched to the system.

In order to work that around, we will detect that the web page was minimized and the call to `execHaloCmdWeb()` will fail under such a circumstance. The web page could reschdule the call once it's maximized again.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [X] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
