### PR TITLE
HaLo: Validate command.message and command.digest for correctness when signing

### DIFF
--- a/halo/commands.js
+++ b/halo/commands.js
@@ -76,6 +76,10 @@ async function cmdSign(options, args) {
             messageBuf = Buffer.from(args.message);
         } else if (!args.format || args.format === "hex") {
             messageBuf = Buffer.from(args.message, "hex");
+
+            if (args.message.length !== messageBuf.length * 2) {
+                throw new HaloLogicError("Failed to decode command.message parameter. If you want to sign text instead of bytes, please use command.format = 'text'.");
+            }
         } else {
             throw new HaloLogicError("Invalid message format specified. Valid formats: text, hex.");
         }
@@ -93,6 +97,10 @@ async function cmdSign(options, args) {
         digestBuf = Buffer.from(hashStr.slice(2), "hex");
     } else if (args.hasOwnProperty("digest") && typeof args.digest !== "undefined") {
         digestBuf = Buffer.from(args.digest, "hex");
+
+        if (args.digest.length !== digestBuf.length * 2 || digestBuf.length !== 32) {
+            throw new HaloLogicError("Failed to decode command.digest parameter. The digest to be signed must be exactly 32 bytes long.");
+        }
     } else {
         throw new HaloLogicError("Either args.digest, args.message or args.typedData is required.");
     }


### PR DESCRIPTION
Right now it's possible to pass malformed `command.message` or `command.digest` value when signing. The buffer will be incorrectly decoded and this might lead to unexpected results or signing a different value than expected. This PR would introduce input validation for these parameters and fail early if something is malformed.

## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [X] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
