### PR TITLE
Web: Add default status callback for Android

### DIFF
--- a/docs/api-web.md
+++ b/docs/api-web.md
@@ -62,8 +62,19 @@ query string parameter, and this parameter is higher or equal `01.C5` (by lexico
 options.statusCallback: null/function
 ```
 
-Optionally, you can provide a callback which will inform you about certain status events while
-the command execution process is ongoing. This could be used to increase user's experience.
+Depending on the command execution method that is used by LibHaLo, the operating system might, or might not
+display the standard NFC scanning prompt.
+
+With the `credential` execution method (mostly user on iOS/Windows platforms), the operating system would display
+a standard NFC scanning prompt that would instruct the user to scan the HaLo tag. This is not the case for
+`webnfc` (mostly on Android) execution method, where there is no standard scanner prompt at all.
+In order to smoothen  the user experience for that platform, LibHaLo will automatically emulate the NFC
+scanning prompt in HTML.
+
+You can customize this behavior by passing `options.statusCallback`. When such callback function is provided,
+the LibHaLo will not inject any HTML content to your website. The callback will be invoked on different steps
+of the NFC scanning process, allowing your web application to provide appropriate instructions to the user
+and increase user experience.
 
 Example callback:
 ```
@@ -86,9 +97,6 @@ The `execMethod` will be either:
 
 * `credential` - if the credential prompt method is being used in order to scan the tag (mostly on iOS/Windows);
 * `webnfc` - if the WebNFC method is used in order to scan the tag (mostly on Android);
-
-The application's frontend could differentiate the UI behavior depending on the `execMethod` that is being used
-by the library in order to provide better user experience.
 
 ### Return value
 

--- a/drivers/web.js
+++ b/drivers/web.js
@@ -150,7 +150,10 @@ async function execHaloCmdWeb(command, options) {
 
         return await execHaloCmd(command, cmdOpts);
     } finally {
-        options.statusCallback(null);
+        if (options.statusCallback) {
+            options.statusCallback(null);
+        }
+
         isCallRunning = false;
     }
 }

--- a/drivers/web.js
+++ b/drivers/web.js
@@ -2,6 +2,7 @@ const {NFCAbortedError, NFCMethodNotSupported} = require("../halo/exceptions");
 const {execCredential} = require("./credential");
 const {execWebNFC} = require("./webnfc");
 const {execHaloCmd} = require("./common");
+const {defaultWebNFCStatusCallback} = require("../web/soft_prompt");
 
 let isCallRunning = null;
 
@@ -32,172 +33,6 @@ function detectMethod() {
     return "webnfc";
 }
 
-function defaultWebNFCStatusCallback(status) {
-    console.log('running default callback'); // TODO
-
-    if (!document.getElementById('__libhalo_popup_stylesheet')) {
-        console.log('injecting scripts'); // TODO
-
-        const style = document.createElement('style');
-        style.setAttribute('id', '__libhalo_popup_stylesheet');
-        style.textContent = `
-@keyframes __libhalo_popup_waitingRingGrow {
-  0% {
-    width: 66px;
-    height: 66px;
-    opacity: 0;
-  }
-  20% {
-    opacity: 0.2;
-  }
-  65% {
-    opacity: 0.2;
-  }
-  100% {
-    opacity: 0;
-    width: 120px;
-    height: 120px;
-  }
-}
-.__libhalo_popup .waiting {
-  color: white;
-  text-align: center;
-}
-.__libhalo_popup .waiting--space-top {
-  padding-top: 120px;
-}
-.__libhalo_popup .waiting--red {
-  color: #fe0133;
-}
-.__libhalo_popup .waiting--blue {
-  color: #0047ff;
-}
-.__libhalo_popup .waiting--green {
-  color: #43a815;
-}
-.__libhalo_popup .waiting {
-  justify-content: center;
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-}
-.__libhalo_popup .waiting-x {
-  width: 60px;
-  height: 60px;
-  position: relative;
-  margin: 25px auto 32px;
-}
-.__libhalo_popup .waiting-x img,
-.__libhalo_popup .waiting-x svg {
-  z-index: 2;
-  position: relative;
-}
-.__libhalo_popup .waiting-x:before, .__libhalo_popup .waiting-x:after {
-  z-index: 1;
-  content: "";
-  width: 40px;
-  height: 40px;
-  border: 1px solid currentColor;
-  border-radius: 50%;
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  opacity: 0.3;
-  transform: translate(-50%, -50%);
-  animation: 3s __libhalo_popup_waitingRingGrow infinite linear;
-}
-.__libhalo_popup .waiting-x:after {
-  animation-delay: 1.5s;
-}
-.__libhalo_popup .waiting-text {
-  font-size: 14px;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: white;
-}
-
-#__libhalo_popup {
-  position: fixed;
-  padding: 10px;
-  max-width: 340px;
-  left: 50%;
-  margin-left: -170px;
-  font-size: 12px;
-  text-align: center;
-  height: 210px;
-  top: 50%;
-  margin-top: -100px;
-  background: #232323;
-  z-index: 20;
-}
-
-#__libhalo_popup:after {
-  position: fixed;
-  content: "";
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  background: rgba(0,0,0,0.5);
-  z-index: -2;
-}
-
-#__libhalo_popup:before {
-  position: absolute;
-  content: "";
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  background: #232323;
-  z-index: -1;
-}`;
-        document.head.append(style);
-    }
-
-    if (!document.getElementById('__libhalo_popup')) {
-        console.log('injecting popup'); // TODO
-
-        const pdiv1 = document.createElement('div');
-        pdiv1.setAttribute('id', '__libhalo_popup');
-        pdiv1.setAttribute('class', '__libhalo_popup');
-        pdiv1.innerHTML = `
-            <div class="waiting">
-                <div class="waiting-x">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" fill="none">
-                        <path
-                            fill="#0c0c0c"
-                            d="M30 60c16.569 0 30-13.431 30-30C60 13.431 46.569 0 30 0 13.431 0 0 13.431 0 30c0 16.569 13.431 30 30 30Z"
-                        />
-                        <path
-                            fill="currentColor"
-                            d="M30 4.79c6.734 0 13.06 2.618 17.826 7.384A25.053 25.053 0 0 1 55.21 30c0 6.733-2.618 13.06-7.384 17.826A25.053 25.053 0 0 1 30 55.21c-6.734 0-13.06-2.618-17.826-7.384A25.053 25.053 0 0 1 4.79 30c0-6.734 2.618-13.06 7.384-17.826A25.053 25.053 0 0 1 30 4.789Zm0-1.247C15.388 3.543 3.543 15.388 3.543 30S15.388 56.456 30 56.456 56.457 44.612 56.457 30 44.612 3.543 30 3.543ZM35.08 30l2.116-3.175 5.096-7.643h-6.499l-4.57 6.859s-.024.031-.031.047l-.063.094a7.054 7.054 0 0 0-1.043 2.76h-.164a7.052 7.052 0 0 0-1.043-2.76l-.063-.094c-.008-.016-.023-.031-.031-.047l-4.57-6.86h-6.499l2.799 4.203L24.928 30l-2.116 3.175-5.096 7.643h6.499l4.57-6.86s.023-.03.031-.047l.063-.094a7.052 7.052 0 0 0 1.043-2.759h.164a7.053 7.053 0 0 0 1.043 2.76l.063.093c.007.016.023.032.03.047l4.571 6.86h6.499l-2.799-4.202L35.08 30Z"
-                        />
-                    </svg>
-                </div>
-                <span class="waiting-text" id="__libhalo_popup_status_text">...</span>
-            </div>`;
-
-        document.body.append(pdiv1);
-    }
-
-    const rdiv = document.getElementById('__libhalo_popup');
-    const pdiv = document.getElementById('__libhalo_popup_status_text');
-    let statusText = '<unknown>';
-
-    switch (status) {
-        case "init": statusText = "Please tap your HaLo tag to the back of your smartphone and hold it for a while..."; break;
-        case "again": statusText = "Almost there... Please tap HaLo tag again..."; break;
-        case "retry": statusText = "Something went wrong, please try again..."; break;
-        case "scanned": statusText = "Scan successful, please wait..."; break;
-        default: statusText = "<" + status + ">"; break;
-    }
-
-    pdiv.innerText = statusText;
-    rdiv.style.display = status !== null ? 'block' : 'none';
-}
-
 /**
  * Execute the NFC command from the web browser.
  * @param command Command specification object.
@@ -215,8 +50,6 @@ async function execHaloCmdWeb(command, options) {
     options.method = makeDefault(options.method, detectMethod());
     options.noDebounce = makeDefault(options.noDebounce, false);
     options.compatibleCallMode = makeDefault(options.compatibleCallMode, true);
-    // FIXME
-    options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
 
     command = command ? Object.assign({}, command) : {};
 
@@ -232,6 +65,8 @@ async function execHaloCmdWeb(command, options) {
                 })
             };
         } else if (options.method === "webnfc") {
+            options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
+
             cmdOpts = {
                 method: "webnfc",
                 exec: async (command) => await execWebNFC(command, {

--- a/drivers/web.js
+++ b/drivers/web.js
@@ -121,8 +121,6 @@ async function execHaloCmdWeb(command, options) {
     options.method = makeDefault(options.method, detectMethod());
     options.noDebounce = makeDefault(options.noDebounce, false);
     options.compatibleCallMode = makeDefault(options.compatibleCallMode, true);
-    // options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
-    options.statusCallback = defaultWebNFCStatusCallback;
 
     command = command ? Object.assign({}, command) : {};
 
@@ -138,6 +136,8 @@ async function execHaloCmdWeb(command, options) {
                 })
             };
         } else if (options.method === "webnfc") {
+            options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
+
             cmdOpts = {
                 method: "webnfc",
                 exec: async (command) => await execWebNFC(command, {

--- a/drivers/web.js
+++ b/drivers/web.js
@@ -41,18 +41,94 @@ function defaultWebNFCStatusCallback(status) {
         const style = document.createElement('style');
         style.setAttribute('id', '__libhalo_popup_stylesheet');
         style.textContent = `
+@keyframes __libhalo_popup_waitingRingGrow {
+  0% {
+    width: 66px;
+    height: 66px;
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.2;
+  }
+  65% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0;
+    width: 120px;
+    height: 120px;
+  }
+}
+.__libhalo_popup .waiting {
+  color: white;
+  text-align: center;
+}
+.__libhalo_popup .waiting--space-top {
+  padding-top: 120px;
+}
+.__libhalo_popup .waiting--red {
+  color: #fe0133;
+}
+.__libhalo_popup .waiting--blue {
+  color: #0047ff;
+}
+.__libhalo_popup .waiting--green {
+  color: #43a815;
+}
+.__libhalo_popup .waiting {
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+.__libhalo_popup .waiting-x {
+  width: 60px;
+  height: 60px;
+  position: relative;
+  margin: 25px auto 32px;
+}
+.__libhalo_popup .waiting-x img,
+.__libhalo_popup .waiting-x svg {
+  z-index: 2;
+  position: relative;
+}
+.__libhalo_popup .waiting-x:before, .__libhalo_popup .waiting-x:after {
+  z-index: 1;
+  content: "";
+  width: 40px;
+  height: 40px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  opacity: 0.3;
+  transform: translate(-50%, -50%);
+  animation: 3s __libhalo_popup_waitingRingGrow infinite linear;
+}
+.__libhalo_popup .waiting-x:after {
+  animation-delay: 1.5s;
+}
+.__libhalo_popup .waiting-text {
+  font-size: 14px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: white;
+}
+
 #__libhalo_popup {
   position: fixed;
   padding: 10px;
-  width: 340px;
+  max-width: 340px;
   left: 50%;
   margin-left: -170px;
   font-size: 12px;
   text-align: center;
-  height: 180px;
+  height: 210px;
   top: 50%;
   margin-top: -100px;
-  background: #FFF;
+  background: #232323;
   z-index: 20;
 }
 
@@ -74,7 +150,7 @@ function defaultWebNFCStatusCallback(status) {
   left: 0;
   bottom: 0;
   right: 0;
-  background: #FFF;
+  background: #232323;
   z-index: -1;
 }`;
         document.head.append(style);
@@ -85,11 +161,29 @@ function defaultWebNFCStatusCallback(status) {
 
         const pdiv1 = document.createElement('div');
         pdiv1.setAttribute('id', '__libhalo_popup');
+        pdiv1.setAttribute('class', '__libhalo_popup');
+        pdiv1.innerHTML = `
+            <div class="waiting">
+                <div class="waiting-x">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" fill="none">
+                        <path
+                            fill="#0c0c0c"
+                            d="M30 60c16.569 0 30-13.431 30-30C60 13.431 46.569 0 30 0 13.431 0 0 13.431 0 30c0 16.569 13.431 30 30 30Z"
+                        />
+                        <path
+                            fill="currentColor"
+                            d="M30 4.79c6.734 0 13.06 2.618 17.826 7.384A25.053 25.053 0 0 1 55.21 30c0 6.733-2.618 13.06-7.384 17.826A25.053 25.053 0 0 1 30 55.21c-6.734 0-13.06-2.618-17.826-7.384A25.053 25.053 0 0 1 4.79 30c0-6.734 2.618-13.06 7.384-17.826A25.053 25.053 0 0 1 30 4.789Zm0-1.247C15.388 3.543 3.543 15.388 3.543 30S15.388 56.456 30 56.456 56.457 44.612 56.457 30 44.612 3.543 30 3.543ZM35.08 30l2.116-3.175 5.096-7.643h-6.499l-4.57 6.859s-.024.031-.031.047l-.063.094a7.054 7.054 0 0 0-1.043 2.76h-.164a7.052 7.052 0 0 0-1.043-2.76l-.063-.094c-.008-.016-.023-.031-.031-.047l-4.57-6.86h-6.499l2.799 4.203L24.928 30l-2.116 3.175-5.096 7.643h6.499l4.57-6.86s.023-.03.031-.047l.063-.094a7.052 7.052 0 0 0 1.043-2.759h.164a7.053 7.053 0 0 0 1.043 2.76l.063.093c.007.016.023.032.03.047l4.571 6.86h6.499l-2.799-4.202L35.08 30Z"
+                        />
+                    </svg>
+                </div>
+                <span class="waiting-text" id="__libhalo_popup_status_text">...</span>
+            </div>`;
 
         document.body.append(pdiv1);
     }
 
-    const pdiv = document.getElementById('__libhalo_popup');
+    const rdiv = document.getElementById('__libhalo_popup');
+    const pdiv = document.getElementById('__libhalo_popup_status_text');
     let statusText = '<unknown>';
 
     switch (status) {
@@ -101,7 +195,7 @@ function defaultWebNFCStatusCallback(status) {
     }
 
     pdiv.innerText = statusText;
-    pdiv.style.display = status !== null ? 'block' : 'none';
+    rdiv.style.display = status !== null ? 'block' : 'none';
 }
 
 /**
@@ -121,6 +215,8 @@ async function execHaloCmdWeb(command, options) {
     options.method = makeDefault(options.method, detectMethod());
     options.noDebounce = makeDefault(options.noDebounce, false);
     options.compatibleCallMode = makeDefault(options.compatibleCallMode, true);
+    // FIXME
+    options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
 
     command = command ? Object.assign({}, command) : {};
 
@@ -136,8 +232,6 @@ async function execHaloCmdWeb(command, options) {
                 })
             };
         } else if (options.method === "webnfc") {
-            options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
-
             cmdOpts = {
                 method: "webnfc",
                 exec: async (command) => await execWebNFC(command, {

--- a/web/examples/demo.html
+++ b/web/examples/demo.html
@@ -76,7 +76,7 @@
             // all options are optional, you can use them to increase user's experience
             let options = {
                 method: method,
-                statusCallback: (cause, execMethod) => {
+                /* statusCallback: (cause, execMethod) => {
                     if (cause === "init") {
                         // explicitly ask the user to tap the tag
                         document.getElementById('statusText').innerText =
@@ -98,7 +98,7 @@
                         document.getElementById('statusText').style.color = 'orange';
                         document.getElementById('statusText').innerText = 'Tag was scanned. Please wait until we compute the result...';
                     }
-                }
+                } */
             };
 
             let command = {

--- a/web/soft_prompt.js
+++ b/web/soft_prompt.js
@@ -1,0 +1,170 @@
+const PROMPT_STYLES = `
+@keyframes __libhalo_popup_waitingRingGrow {
+  0% {
+    width: 66px;
+    height: 66px;
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.2;
+  }
+  65% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0;
+    width: 120px;
+    height: 120px;
+  }
+}
+.__libhalo_popup .waiting {
+  color: white;
+  text-align: center;
+}
+.__libhalo_popup .waiting--space-top {
+  padding-top: 120px;
+}
+.__libhalo_popup .waiting--red {
+  color: #fe0133;
+}
+.__libhalo_popup .waiting--blue {
+  color: #0047ff;
+}
+.__libhalo_popup .waiting--green {
+  color: #43a815;
+}
+.__libhalo_popup .waiting {
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+.__libhalo_popup .waiting-x {
+  width: 60px;
+  height: 60px;
+  position: relative;
+  margin: 25px auto 32px;
+}
+.__libhalo_popup .waiting-x img,
+.__libhalo_popup .waiting-x svg {
+  z-index: 2;
+  position: relative;
+}
+.__libhalo_popup .waiting-x:before, .__libhalo_popup .waiting-x:after {
+  z-index: 1;
+  content: "";
+  width: 40px;
+  height: 40px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  opacity: 0.3;
+  transform: translate(-50%, -50%);
+  animation: 3s __libhalo_popup_waitingRingGrow infinite linear;
+}
+.__libhalo_popup .waiting-x:after {
+  animation-delay: 1.5s;
+}
+.__libhalo_popup .waiting-text {
+  font-size: 14px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: white;
+  margin-top: 20px;
+}
+
+#__libhalo_popup {
+  position: fixed;
+  padding: 20px;
+  width: calc(80vw - 40px);
+  left: 10vw;
+  font-size: 12px;
+  text-align: center;
+  height: 210px;
+  top: 50%;
+  margin-top: -100px;
+  background: #232323;
+  z-index: 99999;
+}
+
+#__libhalo_popup:after {
+  position: fixed;
+  content: "";
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: -2;
+}
+
+#__libhalo_popup:before {
+  position: absolute;
+  content: "";
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: #232323;
+  z-index: -1;
+}`;
+
+const PROMPT_HTML = `
+<div class="waiting">
+    <div class="waiting-x">
+        <svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" fill="none">
+            <path
+                fill="#0c0c0c"
+                d="M30 60c16.569 0 30-13.431 30-30C60 13.431 46.569 0 30 0 13.431 0 0 13.431 0 30c0 16.569 13.431 30 30 30Z"
+            />
+            <path
+                fill="currentColor"
+                d="M30 4.79c6.734 0 13.06 2.618 17.826 7.384A25.053 25.053 0 0 1 55.21 30c0 6.733-2.618 13.06-7.384 17.826A25.053 25.053 0 0 1 30 55.21c-6.734 0-13.06-2.618-17.826-7.384A25.053 25.053 0 0 1 4.79 30c0-6.734 2.618-13.06 7.384-17.826A25.053 25.053 0 0 1 30 4.789Zm0-1.247C15.388 3.543 3.543 15.388 3.543 30S15.388 56.456 30 56.456 56.457 44.612 56.457 30 44.612 3.543 30 3.543ZM35.08 30l2.116-3.175 5.096-7.643h-6.499l-4.57 6.859s-.024.031-.031.047l-.063.094a7.054 7.054 0 0 0-1.043 2.76h-.164a7.052 7.052 0 0 0-1.043-2.76l-.063-.094c-.008-.016-.023-.031-.031-.047l-4.57-6.86h-6.499l2.799 4.203L24.928 30l-2.116 3.175-5.096 7.643h6.499l4.57-6.86s.023-.03.031-.047l.063-.094a7.052 7.052 0 0 0 1.043-2.759h.164a7.053 7.053 0 0 0 1.043 2.76l.063.093c.007.016.023.032.03.047l4.571 6.86h6.499l-2.799-4.202L35.08 30Z"
+            />
+        </svg>
+    </div>
+    <span class="waiting-text" id="__libhalo_popup_status_text">Loading...</span>
+</div>
+`;
+
+function defaultWebNFCStatusCallback(status) {
+    if (!document.getElementById('__libhalo_popup_stylesheet')) {
+        const style = document.createElement('style');
+        style.setAttribute('id', '__libhalo_popup_stylesheet');
+        style.textContent = PROMPT_STYLES;
+        document.head.append(style);
+    }
+
+    if (!document.getElementById('__libhalo_popup')) {
+        console.log('injecting popup'); // TODO
+
+        const pdiv1 = document.createElement('div');
+        pdiv1.setAttribute('id', '__libhalo_popup');
+        pdiv1.setAttribute('class', '__libhalo_popup');
+        pdiv1.innerHTML = PROMPT_HTML;
+
+        document.body.append(pdiv1);
+    }
+
+    const rdiv = document.getElementById('__libhalo_popup');
+    const pdiv = document.getElementById('__libhalo_popup_status_text');
+    let statusText = '<unknown>';
+
+    switch (status) {
+        case "init": statusText = "Please tap your HaLo tag to the back of your smartphone and hold it for a while..."; break;
+        case "again": statusText = "Almost there... Please tap HaLo tag again..."; break;
+        case "retry": statusText = "Something went wrong, please try again..."; break;
+        case "scanned": statusText = "Scan successful, please wait..."; break;
+        default: statusText = "<" + status + ">"; break;
+    }
+
+    pdiv.innerText = statusText;
+    rdiv.style.display = status !== null ? 'block' : 'none';
+}
+
+module.exports = {
+    defaultWebNFCStatusCallback
+};


### PR DESCRIPTION
## Description
Emulate NFC scanning prompt in HTML when `execHaloCmdWeb()` is used with `webnfc` command executor (Android). That would equalize user experience across all platforms when LibHaLo is used in the default configuration.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [x] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [x] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
