### PR TITLE
Web: Implement cancel feature for emulated prompt

### DIFF
--- a/drivers/web.js
+++ b/drivers/web.js
@@ -51,6 +51,9 @@ async function execHaloCmdWeb(command, options) {
     options.noDebounce = makeDefault(options.noDebounce, false);
     options.compatibleCallMode = makeDefault(options.compatibleCallMode, true);
 
+    // FIXME
+    options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
+
     command = command ? Object.assign({}, command) : {};
 
     try {
@@ -80,7 +83,11 @@ async function execHaloCmdWeb(command, options) {
         return await execHaloCmd(command, cmdOpts);
     } finally {
         if (options.statusCallback) {
-            options.statusCallback(null);
+            options.statusCallback("finished", {
+                execMethod: options.method,
+                execStep: "finished",
+                cancelScan: () => null,
+            });
         }
 
         isCallRunning = false;

--- a/drivers/web.js
+++ b/drivers/web.js
@@ -51,9 +51,6 @@ async function execHaloCmdWeb(command, options) {
     options.noDebounce = makeDefault(options.noDebounce, false);
     options.compatibleCallMode = makeDefault(options.compatibleCallMode, true);
 
-    // FIXME
-    options.statusCallback = makeDefault(options.statusCallback, defaultWebNFCStatusCallback);
-
     command = command ? Object.assign({}, command) : {};
 
     try {

--- a/drivers/webnfc.js
+++ b/drivers/webnfc.js
@@ -91,9 +91,17 @@ async function execWebNFC(request, options) {
 
         try {
             if (writeStatus === "nfc-write") {
-                options.statusCallback("init", "webnfc", "nfc-write");
+                options.statusCallback("init", {
+                    execMethod: "webnfc",
+                    execStep: "nfc-write",
+                    cancelScan: () => ctrl.abort(),
+                });
             } else if (writeStatus === "nfc-write-error") {
-                options.statusCallback("retry", "webnfc", "nfc-write-error");
+                options.statusCallback("retry", {
+                    execMethod: "webnfc",
+                    execStep: "nfc-write-error",
+                    cancelScan: () => ctrl.abort(),
+                });
             }
 
             await ndef.write({
@@ -115,7 +123,11 @@ async function execWebNFC(request, options) {
 
     await ndef.scan({signal: ctrl.signal});
 
-    options.statusCallback("again", "webnfc", "nfc-read");
+    options.statusCallback("again", {
+        execMethod: "webnfc",
+        execStep: "nfc-read",
+        cancelScan: () => ctrl.abort(),
+    });
 
     return new Promise((resolve, reject) => {
         ctrl.signal.addEventListener('abort', () => {
@@ -127,7 +139,11 @@ async function execWebNFC(request, options) {
         }
 
         ndef.onreadingerror = (event) => {
-            options.statusCallback("retry", "webnfc", "nfc-read-error");
+            options.statusCallback("retry", {
+                execMethod: "webnfc",
+                execStep: "nfc-read-error",
+                cancelScan: () => ctrl.abort(),
+            });
         };
 
         ndef.onreading = (event) => {
@@ -157,7 +173,11 @@ async function execWebNFC(request, options) {
                     return;
                 }
 
-                options.statusCallback("scanned", "webnfc", "nfc-success");
+                options.statusCallback("scanned", {
+                    execMethod: "webnfc",
+                    execStep: "nfc-success",
+                    cancelScan: () => ctrl.abort(),
+                });
 
                 ndef.onreading = () => null;
                 ndef.onreadingerror = () => null;
@@ -171,7 +191,11 @@ async function execWebNFC(request, options) {
                     });
                 }, 1);
             } catch (e) {
-                options.statusCallback("retry", "webnfc", "nfc-parse-error");
+                options.statusCallback("retry", {
+                    execMethod: "webnfc",
+                    execStep: "nfc-parse-error",
+                    cancelScan: () => ctrl.abort(),
+                });
             }
         };
     });

--- a/web/examples/demo.html
+++ b/web/examples/demo.html
@@ -73,32 +73,36 @@
             let digest = document.getElementById('digest').value;
             let keyNo = document.getElementById('keyNo').value;
 
+            let customStatusCallback = (cause, execMethod) => {
+                if (cause === "init") {
+                    // explicitly ask the user to tap the tag
+                    document.getElementById('statusText').innerText =
+                        'Tap the tag to the back of your smartphone and hold it for a while. ' +
+                        'Using execution method: ' + execMethod;
+                } else if (cause === "again") {
+                    // another tap is needed to complete the operation
+                    document.getElementById('statusText').innerText =
+                        'Keep holding the tag to the back of your smartphone. ' +
+                        'Using execution method: ' + execMethod;
+                } else if (cause === "retry") {
+                    // this callback is invoked when there is a communication error
+                    // the executeNFCCommand() call will be still running and the frontend
+                    // should ask the user to just try to tap the tag again
+                    document.getElementById('statusText').innerText = 'Failed to scan the tag. Please try to tap it again. (' + cause + ').';
+                } else if (cause === "scanned") {
+                    // everything is done on the NFC part, but we need a tiny bit of time to compute the result on the client-side
+                    // the frontend should instruct the user that he can take the tag away already
+                    document.getElementById('statusText').style.color = 'orange';
+                    document.getElementById('statusText').innerText = 'Tag was scanned. Please wait until we compute the result...';
+                }
+            }
+
             // all options are optional, you can use them to increase user's experience
             let options = {
                 method: method,
-                /* statusCallback: (cause, execMethod) => {
-                    if (cause === "init") {
-                        // explicitly ask the user to tap the tag
-                        document.getElementById('statusText').innerText =
-                            'Tap the tag to the back of your smartphone and hold it for a while. ' +
-                            'Using execution method: ' + execMethod;
-                    } else if (cause === "again") {
-                        // another tap is needed to complete the operation
-                        document.getElementById('statusText').innerText =
-                            'Keep holding the tag to the back of your smartphone. ' +
-                            'Using execution method: ' + execMethod;
-                    } else if (cause === "retry") {
-                        // this callback is invoked when there is a communication error
-                        // the executeNFCCommand() call will be still running and the frontend
-                        // should ask the user to just try to tap the tag again
-                        document.getElementById('statusText').innerText = 'Failed to scan the tag. Please try to tap it again. (' + cause + ').';
-                    } else if (cause === "scanned") {
-                        // everything is done on the NFC part, but we need a tiny bit of time to compute the result on the client-side
-                        // the frontend should instruct the user that he can take the tag away already
-                        document.getElementById('statusText').style.color = 'orange';
-                        document.getElementById('statusText').innerText = 'Tag was scanned. Please wait until we compute the result...';
-                    }
-                } */
+                // uncomment this if you want to implement a custom scanner prompt on Android,
+                // by default the LibHaLo will emulate the scanner prompt automatically
+                // statusCallback: customStatusCallback,
             };
 
             let command = {
@@ -111,30 +115,19 @@
             execHaloCmdWeb(command, options)
                 .then((res) => {
                     // operation succeeded, display the result to the user
-                    document.getElementById('statusText').style.color = 'black';
                     document.getElementById('statusText').innerText = JSON.stringify(res, null, 4);
-
-                    document.getElementById('btn-auto').disabled = false;
-                    document.getElementById('btn-credential').disabled = false;
-                    document.getElementById('btn-webnfc').disabled = false;
                 })
                 .catch((e) => {
-                    console.error(e);
-
-                    if (e instanceof NFCAbortedError) {
-                        // in case of multiple calls to executeNFCCommand(), for example when somebody is mashing
-                        // a button, all calls except one will fail by throwing NFCAbortedError
-                        // this exception should be ignored on the frontend
-                    } else {
-                        // the operation has failed, display the reason to the user
-                        document.getElementById('statusText').style.color = 'black';
-                        document.getElementById('statusText').innerText = e;
-
-                        document.getElementById('btn-auto').disabled = false;
-                        document.getElementById('btn-credential').disabled = false;
-                        document.getElementById('btn-webnfc').disabled = false;
-                    }
+                    // the operation has failed, display the reason to the user
+                    console.error('execHaloCmdWeb error', e);
+                    document.getElementById('statusText').innerText = e;
                 });
+
+            document.getElementById('statusText').style.color = 'black';
+
+            document.getElementById('btn-auto').disabled = false;
+            document.getElementById('btn-credential').disabled = false;
+            document.getElementById('btn-webnfc').disabled = false;
         }
     </script>
 </div>

--- a/web/soft_prompt.js
+++ b/web/soft_prompt.js
@@ -127,10 +127,11 @@ const PROMPT_HTML = `
         </svg>
     </div>
     <span class="waiting-text" id="__libhalo_popup_status_text">Loading...</span>
+    <button class="waiting-text" id="__libhalo_popup_cancel_btn">CANCEL</button>
 </div>
 `;
 
-function defaultWebNFCStatusCallback(status) {
+function defaultWebNFCStatusCallback(status, statusObj) {
     if (!document.getElementById('__libhalo_popup_stylesheet')) {
         const style = document.createElement('style');
         style.setAttribute('id', '__libhalo_popup_stylesheet');
@@ -139,8 +140,6 @@ function defaultWebNFCStatusCallback(status) {
     }
 
     if (!document.getElementById('__libhalo_popup')) {
-        console.log('injecting popup'); // TODO
-
         const pdiv1 = document.createElement('div');
         pdiv1.setAttribute('id', '__libhalo_popup');
         pdiv1.setAttribute('class', '__libhalo_popup');
@@ -151,7 +150,8 @@ function defaultWebNFCStatusCallback(status) {
 
     const rdiv = document.getElementById('__libhalo_popup');
     const pdiv = document.getElementById('__libhalo_popup_status_text');
-    let statusText = '<unknown>';
+    const cancelBtn = document.getElementById('__libhalo_popup_cancel_btn');
+    let statusText;
 
     switch (status) {
         case "init": statusText = "Please tap your HaLo tag to the back of your smartphone and hold it for a while..."; break;
@@ -162,7 +162,8 @@ function defaultWebNFCStatusCallback(status) {
     }
 
     pdiv.innerText = statusText;
-    rdiv.style.display = status !== null ? 'block' : 'none';
+    cancelBtn.onclick = statusObj.cancelScan;
+    rdiv.style.display = status !== 'finished' ? 'block' : 'none';
 }
 
 module.exports = {

--- a/web/soft_prompt.js
+++ b/web/soft_prompt.js
@@ -137,7 +137,7 @@ const PROMPT_HTML = `
         </svg>
     </div>
     <span class="waiting-text" id="__libhalo_popup_status_text">Loading...</span>
-    <button class="waiting-text" id="__libhalo_popup_cancel_btn">CANCEL</button>
+    <button class="cancel-button" id="__libhalo_popup_cancel_btn">CANCEL SCAN</button>
 </div>
 `;
 

--- a/web/soft_prompt.js
+++ b/web/soft_prompt.js
@@ -76,6 +76,17 @@ const PROMPT_STYLES = `
   margin-top: 20px;
 }
 
+.__libhalo_popup .cancel-button {
+  width: 100%;
+  font-weight: 600;
+  margin-top: 10px;
+  font-size: 12px;
+  background: #232323;
+  border: 1px solid white;
+  color: white;
+  padding: 10px;
+}
+
 #__libhalo_popup {
   position: fixed;
   padding: 20px;
@@ -83,7 +94,6 @@ const PROMPT_STYLES = `
   left: calc(10vw + 20px);
   font-size: 12px;
   text-align: center;
-  height: 250px;
   top: 50%;
   margin-top: -100px;
   background: #232323;


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Right now the emulated prompt on Android doesn't let the user cancel the NFC operation, although the system-level prompts that appear on Windows/iOS allow the user to cancel the operation without scanning anything.

This PR adds the ability to cancel the operation in the emulated prompt to equalize user experience across all software platforms.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [x] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [x] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
