### PR TITLE
Web: Check WebNFC permission before displaying the emulated prompt

### DIFF
--- a/drivers/webnfc.js
+++ b/drivers/webnfc.js
@@ -53,8 +53,16 @@ async function checkWebNFCPermission() {
 }
 
 async function execWebNFC(request, options) {
-    if (!window.isSecureContext) {
-        throw new NFCMethodNotSupported("This method can be invoked only in the secure context (HTTPS).");
+    let isWebNFCGranted;
+
+    try {
+        isWebNFCGranted = await checkWebNFCPermission();
+    } catch (e) {
+        throw new NFCMethodNotSupported("Internal error when checking WebNFC permission: " + e.toString());
+    }
+
+    if (!isWebNFCGranted) {
+        throw new NFCPermissionRequestDenied("NFC permission request denied by the user.");
     }
 
     options = Object.assign({}, options) || {};


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Avoid emulated prompt from clipping when the WebNFC permission was previously denied by the user.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [X] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
