### PR TITLE
Fix bug with EIP191 message signing

### DIFF
--- a/halo/commands.js
+++ b/halo/commands.js
@@ -95,7 +95,7 @@ async function cmdSign(options, args) {
             throw new HaloLogicError("Invalid message format specified. Valid formats: text, hex.");
         }
 
-        digestBuf = Buffer.from(ethers.utils.hashMessage(messageBuf).slice(2), "hex");
+        digestBuf = Buffer.from(ethers.utils.hashMessage('0x' + messageBuf.toString('hex')).slice(2), "hex");
     } else if (args.hasOwnProperty("typedData") && typeof args.typedData !== "undefined") {
         let hashStr;
 


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
There is a bug in how input is passed to `ethers.utils.hashMessage()` when doing EIP 191 signing of the specified hex message.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [x] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
