### PR TITLE
HaLo: Fix EIP-191 signing for format=hex.

### DIFF
--- a/halo/commands.js
+++ b/halo/commands.js
@@ -86,16 +86,22 @@ async function cmdSign(options, args) {
         if (args.format === "text") {
             messageBuf = Buffer.from(args.message);
         } else if (!args.format || args.format === "hex") {
-            messageBuf = Buffer.from(args.message, "hex");
+            let msg = args.message;
 
-            if (args.message.length !== messageBuf.length * 2) {
+            if (msg.startsWith("0x")) {
+                msg = msg.substring(2);
+            }
+
+            messageBuf = Buffer.from(msg, "hex");
+
+            if (msg.length !== messageBuf.length * 2) {
                 throw new HaloLogicError("Failed to decode command.message parameter. If you want to sign text instead of bytes, please use command.format = 'text'.");
             }
         } else {
             throw new HaloLogicError("Invalid message format specified. Valid formats: text, hex.");
         }
 
-        digestBuf = Buffer.from(ethers.utils.hashMessage('0x' + messageBuf.toString('hex')).slice(2), "hex");
+        digestBuf = Buffer.from(ethers.utils.hashMessage([...messageBuf]).slice(2), "hex");
     } else if (args.hasOwnProperty("typedData") && typeof args.typedData !== "undefined") {
         let hashStr;
 


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Fix a bug that caused EIP-191 hex-formatted messages to be signed incorrectly (as UTF-8 strings). Add a possibility to pass the message in hex format with `0x` prefix.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
