### PR TITLE
Drivers: Remove caching functionality from readNDEF

### DIFF
--- a/drivers/nfc_manager.js
+++ b/drivers/nfc_manager.js
@@ -38,7 +38,7 @@ async function execHaloCmdRN(nfcManager, command, options) {
 
     if (command.name === "read_ndef") {
         let wrappedTransceive = async (payload) => Buffer.from(await nfcManager.isoDepHandler.transceive([...payload]));
-        return await readNDEF(wrappedTransceive, {allowCache: true});
+        return await readNDEF(wrappedTransceive);
     } else {
         return await execHaloCmd(command, {
             method: 'nfc-manager',

--- a/drivers/pcsc.js
+++ b/drivers/pcsc.js
@@ -63,7 +63,7 @@ async function getVersion(reader) {
     if (versionRes.slice(-2).compare(Buffer.from([0x90, 0x00])) !== 0) {
         // GET_FV_VERSION command not supported, fallback to NDEF
         let wrappedTransceive = async (payload) => await transceive(reader, payload, {noCheck: true});
-        let url = await readNDEF(wrappedTransceive, {allowCache: true});
+        let url = await readNDEF(wrappedTransceive);
 
         if (!url.qs.v) {
             return '01.C1.000001.00000000';
@@ -198,7 +198,7 @@ async function execHaloCmdPCSC(command, reader) {
     } else if (command.name === "read_ndef") {
         // PCSC-specific NDEF reader command
         let wrappedTransceive = async (payload) => await transceive(reader, payload, {noCheck: true});
-        return await readNDEF(wrappedTransceive, {allowCache: true});
+        return await readNDEF(wrappedTransceive);
     } else if (command.name === "full_gen_key") {
         await selectCore(reader);
 

--- a/drivers/read_ndef.js
+++ b/drivers/read_ndef.js
@@ -8,15 +8,7 @@ const Buffer = require('buffer/').Buffer;
 const queryString = require('query-string');
 const {HaloLogicError} = require("../halo/exceptions");
 
-let cachedResult = null;
-
-async function readNDEF(transceive, options) {
-    options = options || {};
-
-    if (options.allowCache && cachedResult) {
-        return cachedResult;
-    }
-
+async function readNDEF(transceive) {
     let resSelect = await transceive(Buffer.from("00A4040007D276000085010100", "hex"));
 
     if (resSelect.compare(Buffer.from([0x90, 0x00])) !== 0) {
@@ -85,16 +77,10 @@ async function readNDEF(transceive, options) {
     fullBuf = fullBuf.slice(4 + skipLen, 4 + skipLen + lengthData);
     let parsed = queryString.parseUrl(fullBuf.toString());
 
-    let out = {
+    return {
         url: parsed.url,
         qs: {...parsed.query}
     };
-
-    if (options.allowCache) {
-        cachedResult = out;
-    }
-
-    return out;
 }
 
 module.exports = {readNDEF};


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
There is a legacy caching functionality in the `readNDEF()` method which causes LibHaLo to cache the first valid NDEF. That is not correct since the lib user might want to scan multiple tags in a single session.


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [x] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
