### PR TITLE
CLI: Implement --reader switch to specify a particular PC/SC reader.

### DIFF
--- a/cli/args_bridge.js
+++ b/cli/args_bridge.js
@@ -39,6 +39,9 @@ parser.add_argument("--non-interactive", {
     action: "store_true",
     "default": false
 });
+parser.add_argument("--reader", {
+    help: "Name of the PC/SC reader to be used."
+});
 
 function parseArgs() {
     return parser.parse_args();

--- a/cli/args_cli.js
+++ b/cli/args_cli.js
@@ -12,6 +12,7 @@ const parser = new ArgumentParser({
     description: 'HaLo - Command Line Tool for PC/SC'
 });
 parser.add_argument("-o", "--output", {help: "Output format, either: color (default, better for humans), json (better for scripts).", "default": "color"});
+parser.add_argument("--reader", {help: "Name of the PC/SC reader to be used."});
 
 const subparsers = parser.add_subparsers({help: 'command', dest: 'name'});
 

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -38,14 +38,21 @@ async function checkCard(reader) {
 
 function runHalo(entryMode, args) {
     nfc.on('reader', reader => {
+        reader.autoProcessing = false;
+
+        reader.on('error', err => {
+            console.log(`${reader.reader.name} an error occurred`, err);
+        });
+
+        if (args.reader && args.reader !== reader.reader.name) {
+            return;
+        }
 
         if (args.name === "pcsc_detect") {
             console.log('Detected PC/SC reader:', reader.reader.name);
         } else if (entryMode === "server") {
             wsEventReaderConnected(reader);
         }
-
-        reader.autoProcessing = false;
 
         reader.on('card', card => {
             if (entryMode === "server") {
@@ -121,11 +128,6 @@ function runHalo(entryMode, args) {
                 wsEventReaderDisconnected(reader);
             }
         });
-
-        reader.on('error', err => {
-            console.log(`${reader.reader.name} an error occurred`, err);
-        });
-
     });
 
     nfc.on('error', err => {


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->

In case when somebody has multiple PC/SC readers attached, we provide a `--reader` CLI option to specify a particular reader that should be used by `halocli` or `halo-bridge`. The list of connected readers can be obtained by using `halocli pcsc_detect` (without any switches).

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
