### PR TITLE
HaLo: Properly parse keySlotFlags and keySlotFailedAuthCtr in get_data_struct

### DIFF
--- a/docs/halo-command-set.md
+++ b/docs/halo-command-set.md
@@ -860,8 +860,8 @@ The `spec` value is expected to be formatted as:
 Where the acceptable object types are:
 * `publicKey` - the uncompressed public key corresponding to the particular key slot;
 * `publicKeyAttest` - the public key's attest signature;
-* `keySlotFlags` - status flags corresponding to the particular key slot;
-* `keySlotFailedAuthCtr` - failed password authentication counter of the particular key slot;
+* `keySlotFlags` - status flags corresponding to the particular key slot (returned as an object);
+* `keySlotFailedAuthCtr` - failed password authentication counter of the particular key slot (returned as a number);
 * `latchValue` - value of the latch (possible object IDs: 1, 2);
 * `latchAttest` - attest signature of the latch;
 * `graffiti` - value of the rewritable data slot (possible object IDs: 1);

--- a/halo/commands.js
+++ b/halo/commands.js
@@ -14,7 +14,7 @@ const EC = require("elliptic").ec;
 const CMD = require('./cmdcodes').CMD_CODES;
 const pbkdf2 = require('pbkdf2');
 const crypto = require('crypto-browserify');
-const {KEY_FLAGS} = require("./keyflags");
+const {KEY_FLAGS, parseKeyFlags} = require("./keyflags");
 
 const ec = new EC('secp256k1');
 
@@ -504,11 +504,7 @@ async function cmdGetKeyInfo(options, args) {
 
     return {
         keyState: {
-            isPasswordProtected: !!(keyFlags & KEY_FLAGS.KEYFLG_IS_PWD_PROTECTED),
-            hasMandatoryPassword: !!(keyFlags & KEY_FLAGS.KEYFLG_MANDATORY_PASSWORD),
-            rawSignCommandNotUsed: !!(keyFlags & KEY_FLAGS.KEYFLG_SIGN_NOT_USED),
-            isImported: !!(keyFlags & KEY_FLAGS.KEYFLG_IS_IMPORTED),
-            isExported: !!(keyFlags & KEY_FLAGS.KEYFLG_IS_EXPORTED),
+            ...parseKeyFlags(keyFlags),
             failedAuthCounter: failedAuthCtr
         },
         publicKey: publicKey.toString('hex'),
@@ -764,6 +760,11 @@ async function cmdGetDataStruct(options, args) {
             } else {
                 value = {"error": 'unknown_' + msgCode.toString()};
             }
+        } else if (item[0] === "keySlotFlags") {
+            let keyFlags = res.slice(1, len + 1)[0];
+            value = parseKeyFlags(keyFlags);
+        } else if (item[0] === "keySlotFailedAuthCtr") {
+            value = res.slice(1, len + 1)[0];
         } else {
             const encoding = item[0] !== "graffiti" ? "hex" : "utf-8";
 

--- a/halo/keyflags.js
+++ b/halo/keyflags.js
@@ -13,4 +13,14 @@ const KEY_FLAGS = {
     KEYFLG_IS_EXPORTED:        0x20
 }
 
-module.exports = {KEY_FLAGS};
+function parseKeyFlags(keyFlags) {
+    return {
+        isPasswordProtected: !!(keyFlags & KEY_FLAGS.KEYFLG_IS_PWD_PROTECTED),
+        hasMandatoryPassword: !!(keyFlags & KEY_FLAGS.KEYFLG_MANDATORY_PASSWORD),
+        rawSignCommandNotUsed: !!(keyFlags & KEY_FLAGS.KEYFLG_SIGN_NOT_USED),
+        isImported: !!(keyFlags & KEY_FLAGS.KEYFLG_IS_IMPORTED),
+        isExported: !!(keyFlags & KEY_FLAGS.KEYFLG_IS_EXPORTED)
+    };
+}
+
+module.exports = {KEY_FLAGS, parseKeyFlags};


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [x] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
