### PR TITLE
Log usage statistics & stats subpage

### DIFF
--- a/cli/assets/static/style.css
+++ b/cli/assets/static/style.css
@@ -50,6 +50,16 @@ h6 {
   width: 100%;
 }
 
+.container-lg {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 1000px;
+  width: calc(100% - 40px);
+  width: 100%;
+}
+
 .box {
   background: #fcfcfc;
   border-radius: 8px;
@@ -145,4 +155,23 @@ svg {
 
 .flex-buttons .button {
   flex: 1;
+}
+
+.margin-top-20px {
+  margin-top: 20px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #dddddd;
 }

--- a/cli/assets/views/stats.html
+++ b/cli/assets/views/stats.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/assets/static/style.css" />
+    <title>HaLo Gateway Server</title>
+  </head>
+  <body>
+    <div class="container">
+      <div class="box">
+        {% for item in data %}
+          <h1>{{ item['year'] }}.{{ item['month'] }}</h1>
+          <p>
+            <b>Total connections:</b> {{ item['total_connections'] }}<br />
+            <b>Total processed commands:</b> {{ item['total_processed_commands'] }}<br />
+            <b>Total unique IPs:</b> {{ item['total_unique_ips'] }}<br />
+          </p>
+        {% endfor %}
+      </div>
+    </div>
+  </body>
+</html>

--- a/cli/assets/views/stats.html
+++ b/cli/assets/views/stats.html
@@ -6,17 +6,42 @@
     <title>HaLo Gateway Server</title>
   </head>
   <body>
-    <div class="container">
+    <div class="container-lg">
       <div class="box">
+        <h1>Statistics</h1>
+        {% if data|length > 0 %}
+          {% set prevMonth = none %}
+          {% set prevYear = none %}
+        {% endif %}
+
+
         {% for item in data %}
-          <h1>{{ item['year'] }}.{{ item['month'] }}</h1>
-          <p>
-            <b>Total connections:</b> {{ item['total_connections'] }}<br />
-            <b>Total processed commands:</b> {{ item['total_processed_commands'] }}<br />
-            <b>Total unique IPs:</b> {{ item['total_unique_ips'] }}<br />
-          </p>
+          {% if prevYear != item['year'] or prevMonth != item['month'] %}
+            <h3 class="margin-top-20px">{{ "0" + item['month'] if item['month'] < 10 else item['month'] }}.{{ item['year'] }}</h3>
+            <table>
+              <tr>
+                <th>Origin Domain</th>
+                <th>Total Connections</th>
+                <th>Total Processed Commands</th>
+                <th>Total Unique IPs</th>
+              </tr>
+          {% endif %}
+          <tr>
+            <td>{{ item['origin'] }} {{loop.index}} {{data|length}}</td>
+            <td>{{ item['total_connections'] }}</td>
+            <td>{{ item['total_processed_commands'] }}</td>
+            <td>{{ item['total_unique_ips'] }}</td>
+          </tr>
+
+          {% set prevMonth = item['month'] %}
+          {% set prevYear = item['year'] %}
+
+          {% if data[loop.index + 1]['month'] != prevMonth and data[loop.index + 1]['year'] != prevYear %}
+            </table>
+          {% endif %}
         {% endfor %}
       </div>
     </div>
   </body>
 </html>
+

--- a/cli/src.ts/args_gateway.ts
+++ b/cli/src.ts/args_gateway.ts
@@ -21,6 +21,12 @@ parser.add_argument("-p", "--listen-port", {
     default: 32842,
     dest: "listenPort"
 });
+parser.add_argument("-d", "--disable-stats", {
+    help: "Whether to disable the /stats page",
+    default: false,
+    dest: "disableStats",
+    action: "store_true"
+});
 
 function parseArgs() {
     return parser.parse_args();

--- a/cli/src.ts/entry_gateway.ts
+++ b/cli/src.ts/entry_gateway.ts
@@ -14,7 +14,7 @@ import {parse} from "url";
 
 import {parseArgs} from './args_gateway.js';
 import {printVersionInfo, getBuildInfo} from "./version.js";
-import {dirname} from "./util.js";
+import {dirname, saveLog} from "./util.js";
 import {Namespace} from "argparse";
 
 const buildInfo = getBuildInfo();
@@ -51,6 +51,13 @@ function processRequestor(ws: WebSocket, req: IncomingMessage) {
     }
 
     console.log('[' + sessionId + '] Requestor connected. ' + ipStr);
+
+    const log_to_save = {
+        event_name: "Requestor connected",
+        origin: req.headers['origin'] || "Unknown",
+        ip: req.socket.remoteAddress || "Unknown",
+    };
+    saveLog(log_to_save);
 
     sessionIds[sessionId] = {
         "requestor": ws,
@@ -94,6 +101,12 @@ function processRequestor(ws: WebSocket, req: IncomingMessage) {
                     "payload": obj.payload
                 }));
                 console.log('[' + sessionId + '] Command request sent to executor.');
+                const log_to_save = {
+                    event_name: "Command request sent to executor",
+                    origin: req.headers['origin'] || "Unknown",
+                    ip: req.socket.remoteAddress || "Unknown",
+                };
+                saveLog(log_to_save);
             } else {
                 sobj.requestor.send(JSON.stringify({
                     "uid": obj.uid,

--- a/cli/src.ts/entry_gateway.ts
+++ b/cli/src.ts/entry_gateway.ts
@@ -55,6 +55,7 @@ function processRequestor(ws: WebSocket, req: IncomingMessage) {
     const log_to_save = {
         event_name: "Requestor connected",
         origin: req.headers['origin'] || "Unknown",
+        forwarded_for: req.headers['x-forwarded-for'] || "Unknown",
         ip: req.socket.remoteAddress || "Unknown",
     };
     saveLog(log_to_save);

--- a/cli/src.ts/entry_gateway.ts
+++ b/cli/src.ts/entry_gateway.ts
@@ -264,7 +264,7 @@ function createServer(args: Namespace) {
               >
             > = {};
             for (const [yyyy_mm, logData] of Object.entries(logs)) {
-                const uniqueIps = new Set<string>();
+                const uniqueIps: Record<string, Set<string>> = {}
                 const length = Object.entries(logData).length;
                 for (const [index, log] of logData.entries()) {
                     const origin = log.origin;
@@ -282,7 +282,10 @@ function createServer(args: Namespace) {
                     }
     
                     // Add IP to the set
-                    uniqueIps.add(log.ip);
+                    if (!uniqueIps[origin]) {
+                        uniqueIps[origin] = new Set();
+                    }
+                    uniqueIps[origin].add(log.ip);
     
                     // Handle different log events
                     if (log.event_name === "Requestor connected") {
@@ -291,10 +294,8 @@ function createServer(args: Namespace) {
                         data[yyyy_mm][origin].total_processed_commands++;
                     }
     
-                    // Update the total unique IPs if it's the last log entry
-                    if (index === length - 1) {
-                        data[yyyy_mm][origin].total_unique_ips = uniqueIps.size;
-                    }
+                    // Update the total unique IPs
+                    data[yyyy_mm][origin].total_unique_ips = uniqueIps[origin].size;
                 }
             }
     

--- a/cli/src.ts/entry_gateway.ts
+++ b/cli/src.ts/entry_gateway.ts
@@ -105,6 +105,7 @@ function processRequestor(ws: WebSocket, req: IncomingMessage) {
                 const log_to_save = {
                     event_name: "Command request sent to executor",
                     origin: req.headers['origin'] || "Unknown",
+                    forwarded_for: req.headers['x-forwarded-for'] || "Unknown",
                     ip: req.socket.remoteAddress || "Unknown",
                 };
                 saveLog(log_to_save);

--- a/cli/src.ts/util.ts
+++ b/cli/src.ts/util.ts
@@ -1,9 +1,37 @@
 import { fileURLToPath } from 'node:url';
 import { dirname as path_dirname, join as path_join } from 'node:path';
 import crypto from "crypto";
+import fs from "fs";
 
 function randomBuffer() {
     return Buffer.from(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+function saveLog(log: Record<string, string>) {
+    const now = new Date();
+    const month = now.getMonth() + 1;
+    const year = now.getFullYear();
+    const filename = `${year}_${month}.ndjson`;
+    const logDir = path_join(dirname, "logs");
+    const logPath = path_join(logDir, filename);
+
+    const alteredLog = {
+        iso_timestamp: (new Date).toISOString(),
+        timestamp: String(Date.now()),
+        ...log,
+    }
+
+    // Create log directory if it doesn't exist
+    if (!fs.existsSync(logDir)) {
+        fs.mkdirSync(logDir);
+    }
+    
+    // Create/append to log file
+    fs.appendFile(logPath, JSON.stringify(alteredLog) + "\n", (err) => {
+        if (err) {
+            console.log("saveLog() failed: ", err);
+        }
+    });
 }
 
 let dirname: string;
@@ -18,4 +46,4 @@ if (process.pkg && process.pkg.entrypoint) {
     console.log(dirname);
 }
 
-export {dirname, randomBuffer};
+export {dirname, randomBuffer, saveLog};

--- a/cli/src.ts/util.ts
+++ b/cli/src.ts/util.ts
@@ -7,7 +7,7 @@ function randomBuffer() {
     return Buffer.from(crypto.getRandomValues(new Uint8Array(32)));
 }
 
-function saveLog(log: Record<string, string>) {
+function saveLog(log: Record<string, string | string[]>) {
     const now = new Date();
     const month = now.getMonth() + 1;
     const year = now.getFullYear();


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
* Gather  "Requestor connected" and "Command request sent to executor" logs and save them to cli/logs/yyyy_dd.ndjson
* Save x-forwarded-for header in logs
* Added stats(/stats) page which displays data about total total connections, total processed commands & total unique IPs for every recorded origin domain for every log present in cli/logs/
* Stats page can be disabled by --disable-stats(-d) flag


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
