### PR TITLE
Halo: always pick "credential" execution method by default

### DIFF
--- a/core/src.ts/drivers/web.ts
+++ b/core/src.ts/drivers/web.ts
@@ -30,19 +30,11 @@ function makeDefault<Type>(curValue: Type | null | undefined, defaultValue: Type
 
 /**
  * Detect the best command execution method for the current device.
- * @returns {string} Either "credential" or "webnfc".
+ * Historically, this method was trying to pick the best among "credential" or "webnfc".
+ * Right now it is going to statically return "credential" in all cases.
  */
-export function detectMethod() {
-    try {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        new window.NDEFReader();
-    } catch (e) {
-        // WebNFC not supported
-        return "credential";
-    }
-
-    return "webnfc";
+export function detectMethod(): "credential" {
+    return "credential";
 }
 
 function defaultStatusCallback(cause: string, statusObj: StatusCallbackDetails) {


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->
Historically, the `detectMethod()` function was prioritizing the choice of WebNFC execution method as a default method if it was available on the current platform. This PR will change that in order to always use the `"credential"` execution method, since its general UX has improved a lot in the meantime.

## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
