### PR TITLE
Bridge: Open Burner OS webpage by default when the bridge is started

### DIFF
--- a/cli/src.ts/cli.ts
+++ b/cli/src.ts/cli.ts
@@ -220,7 +220,7 @@ function runHalo(entryMode: string, args: Namespace) {
         console.log('HaLo Bridge Server is listening...');
 
         if (!args.nonInteractive) {
-            open('http://127.0.0.1:' + args.listenPort);
+            open('https://os.burner.pro/');
         }
     } else {
         stopPCSCTimeout = setTimeout(stopPCSC, 4000, "timeout", args.output);


### PR DESCRIPTION
## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
