### PR TITLE
Revert detectMethod() implementation back to WebNFC preference where available

### DIFF
--- a/core/src.ts/drivers/web.ts
+++ b/core/src.ts/drivers/web.ts
@@ -33,38 +33,18 @@ function makeDefault<Type>(curValue: Type | null | undefined, defaultValue: Type
 
 /**
  * Detect the best command execution method for the current device.
- * Historically, this method was trying to pick the best among "credential" or "webnfc".
- * Right now it is going to statically return "credential" in all cases.
+ * @returns {string} Either "credential" or "webnfc".
  */
 export function detectMethod() {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    if (navigator && navigator.userAgentData && navigator.userAgentData.mobile && navigator.userAgentData.brands) {
+    try {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
-        const chromeVerObj = navigator.userAgentData.brands.filter(
-            (o: { brand: string; version: string; }) => o.brand == "Google Chrome");
-
-        if (chromeVerObj.length === 1 && typeof chromeVerObj[0].version === "string") {
-            const chromeVer = parseInt(chromeVerObj[0].version);
-
-            if (chromeVer < 124) {
-                // we want to use WebNFC on older Chrome Android (version <124)
-                // newer Chrome versions contain proper Credential API UX
-
-                try {
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
-                    new window.NDEFReader();
-                    return "webnfc";
-                } catch (e) {
-                    // pass
-                }
-            }
-        }
+        new window.NDEFReader();
+    } catch (e) {
+        // WebNFC not supported
+        return "credential";
     }
-
-    return "credential";
+    return "webnfc";
 }
 
 function defaultStatusCallback(cause: string, statusObj: StatusCallbackDetails) {


### PR DESCRIPTION

## Description
<!-- Thanks for contributing to LibHaLo! Please provide a short description of your PR. -->


## Checklist

<!-- Please check the applicable checkboxes. Please do not edit the contents of the checklist. -->

### Changes to the drivers

<!-- If drivers/ subdirectory was modified. -->
* [ ] (PR Author) The affected drivers were manually tested

### Changes to CLI

<!-- If cli/ directory or pcsc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the CLI
* [ ] (PR Author) The affected CLI features are working with the standalone binary (at least one platform)
* [ ] (Checked by maintainer) The CLI test procedure was run by the project's maintainer

### Changes to web library

<!-- If web/ subdirectory or credential/webnfc driver was modified. -->
* [ ] (PR Author) The change was manually tested with the web library included within a classic HTML application (flat `libhalo.js`)
* [ ] (PR Author) The change was manually tested with the web library included within an app based on frontend framework (React.js or similar based on webpack)
* [ ] (Checked by maintainer) The web test suite was run by the project's maintainer

### Changes to nfc-manager driver

<!-- If nfc-manager driver was modified. -->
* [ ] (PR Author) The change was manually tested in React Native app
* [ ] (Checked by maintainer) The test suite was run through the test React Native project
